### PR TITLE
Add content available flag.

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -30,6 +30,13 @@ class Message implements \JsonSerializable
     private $delayWhileIdle;
 
     /**
+     * Represents the app's "Send-to-Sync" message.
+     *
+     * @var bool
+     */
+    private $contentAvailableFlag;
+
+    /**
      * where should the message go
      *
      * @param Recipient $recipient
@@ -116,6 +123,16 @@ class Message implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * @see https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_and_non-collapsible_messages
+     *
+     * @return \paragraph1\phpFCM\Message
+     */
+    public function setContentAvailable() {
+        $this->contentAvailableFlag = TRUE;
+        return $this;
+    }
+
     public function setData(array $data)
     {
         $this->data = $data;
@@ -148,6 +165,9 @@ class Message implements \JsonSerializable
         }
         if ($this->delayWhileIdle) {
             $jsonData['delay_while_idle'] = (bool)$this->delayWhileIdle;
+        }
+        if ($this->contentAvailableFlag === TRUE) {
+            $jsonData['content_available'] = TRUE;
         }
 
         return $jsonData;

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -138,4 +138,28 @@ class MessageTest extends PhpFcmTestCase
         $this->setExpectedException(\UnexpectedValueException::class);
         $this->fixture->addRecipient(\Mockery::mock(Recipient::class));
     }
+
+    public function testJsonEncodeWorksWithContentAvailableFlag()
+    {
+        $body = '{"to":"deviceId","priority":"high","content_available":true}';
+
+        $this->fixture->setContentAvailable();
+        $this->fixture->addRecipient(new Device('deviceId'));
+        $this->assertSame(
+            $body,
+            json_encode($this->fixture)
+        );
+    }
+
+    public function testJsonEncodeWorksWithoutContentAvailableFlag()
+    {
+        $body = '{"to":"deviceId","priority":"high"}';
+
+        $this->fixture->addRecipient(new Device('deviceId'));
+        $this->assertSame(
+            $body,
+            json_encode($this->fixture)
+        );
+    }
+
 }


### PR DESCRIPTION
Hi @palbertini (or any other contributor) hope you don't mind a pull request. I've noticed the PHP API does not have the content_available flag which is an option in the Firebase messaging API: https://firebase.google.com/docs/cloud-messaging/http-server-ref I've added a straighforward implementation of the flag-turn-on. Please let me know if you have any feedback. I'd like to use the library for silent notifications and this addition is a must for that (as well as seem to be an obvious addition to your code).
Tests included.
