### PR TITLE
Make title field optional

### DIFF
--- a/src/Notification.php
+++ b/src/Notification.php
@@ -130,10 +130,14 @@ class Notification implements \JsonSerializable
 
     public function jsonSerialize()
     {
-        $jsonData = array(
-            'title' => $this->title,
-            'body' => $this->body
-        );
+        $jsonData = array();
+
+        if ($this->title) {
+            $jsonData['title'] = $this->title;
+        }
+
+        $jsonData['body'] = $this->body;
+
         if ($this->badge) {
             $jsonData['badge'] = $this->badge;
         }


### PR DESCRIPTION
Title is optional notification optional field, when it not set - android set app name as title

https://firebase.google.com/docs/cloud-messaging/http-server-ref
title	Optional, string	Indicates notification title.