### PR TITLE
Add Notification Parameters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 .project
 .buildpath
 .settings
+.idea

--- a/src/Notification.php
+++ b/src/Notification.php
@@ -14,8 +14,12 @@ class Notification implements \JsonSerializable
     private $sound;
     private $clickAction;
     private $tag;
+    private $bodyLocKey;
+    private $bodyLocArgs;
+    private $titleLocKey;
+    private $titleLocArgs;
 
-    public function __construct($title, $body)
+    public function __construct($title = null, $body = null)
     {
         $this->title = $title;
         $this->body = $body;
@@ -128,6 +132,54 @@ class Notification implements \JsonSerializable
         return $this;
     }
 
+    /**
+     * android/ios: The key to the body string in the app's string resources to use to localize the body
+     * text to the user's current localization.
+     * @see https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support
+     *
+     * @param string $bodyLocKey
+     */
+    public function setBodyLocKey($bodyLocKey)
+    {
+        $this->bodyLocKey = $bodyLocKey;
+    }
+
+    /**
+     * android/ios: Variable string values to be used in place of the format specifiers in body_loc_key to
+     * use to localize the body text to the user's current localization.
+     * @see https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support
+     *
+     * @param array $bodyLocArgs
+     */
+    public function setBodyLocArgs(array $bodyLocArgs)
+    {
+        $this->bodyLocArgs = $bodyLocArgs;
+    }
+
+    /**
+     * android/ios: The key to the title string in the app's string resources to use to localize the title
+     * text to the user's current localization.
+     * @see https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support
+     *
+     * @param string $titleLocKey
+     */
+    public function setTitleLocKey($titleLocKey)
+    {
+        $this->titleLocKey = $titleLocKey;
+    }
+
+    /**
+     * android/ios:  Variable string values to be used in place of the format specifiers in title_loc_key
+     * to use to localize the title text to the user's current localization.
+     * @see https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support
+     *
+     * @param array $titleLocArgs
+     */
+    public function setTitleLocArgs(array $titleLocArgs)
+    {
+        $this->titleLocArgs = $titleLocArgs;
+    }
+
     public function jsonSerialize()
     {
         $jsonData = array();
@@ -135,9 +187,9 @@ class Notification implements \JsonSerializable
         if ($this->title) {
             $jsonData['title'] = $this->title;
         }
-
-        $jsonData['body'] = $this->body;
-
+        if ($this->body) {
+            $jsonData['body'] = $this->body;
+        }
         if ($this->badge) {
             $jsonData['badge'] = $this->badge;
         }
@@ -155,6 +207,18 @@ class Notification implements \JsonSerializable
         }
         if ($this->tag) {
             $jsonData['tag'] = $this->tag;
+        }
+        if ($this->bodyLocKey) {
+            $jsonData['body_loc_key'] = $this->bodyLocKey;
+        }
+        if ($this->bodyLocArgs) {
+            $jsonData['body_loc_args'] = json_encode($this->bodyLocArgs);
+        }
+        if ($this->titleLocKey) {
+            $jsonData['title_loc_key'] = $this->titleLocKey;
+        }
+        if ($this->titleLocArgs) {
+            $jsonData['title_loc_args'] = json_encode($this->titleLocArgs);
         }
 
         return $jsonData;

--- a/tests/NotificationTest.php
+++ b/tests/NotificationTest.php
@@ -15,42 +15,66 @@ class NotificationTest extends PhpFcmTestCase
 
     public function testJsonSerializeWithMinimalConfigurations()
     {
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar'), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithBadge()
     {
         $this->fixture->setBadge(1);
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'badge' => 1), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'badge' => 1), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithIcon()
     {
         $this->fixture->setIcon('name');
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'icon' => 'name'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'icon' => 'name'), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithClickAction()
     {
         $this->fixture->setClickAction('INTENT_NAME');
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'click_action' => 'INTENT_NAME'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'click_action' => 'INTENT_NAME'), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithSound()
     {
         $this->fixture->setSound('mySound.mp3');
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'sound' => 'mySound.mp3'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'sound' => 'mySound.mp3'), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithColor()
     {
         $this->fixture->setColor('#ffffff');
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'color' => '#ffffff'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'color' => '#ffffff'), $this->fixture->jsonSerialize());
     }
 
     public function testJsonSerializeWithTag()
     {
         $this->fixture->setTag('foo');
-        $this->assertEquals(array('title' => 'foo', 'body' =>'bar', 'tag' => 'foo'), $this->fixture->jsonSerialize());
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'tag' => 'foo'), $this->fixture->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithTitleLoc()
+    {
+        $locKey = 'app_name';
+        $locArgs = [
+            'justApp'
+        ];
+
+        $this->fixture->setTitleLocKey($locKey);
+        $this->fixture->setTitleLocArgs($locArgs);
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'title_loc_key' => $locKey, 'title_loc_args' => json_encode($locArgs)), $this->fixture->jsonSerialize());
+    }
+
+    public function testJsonSerializeWithBodyLoc()
+    {
+        $locKey = 'sb_has_sent_a_voice_message';
+        $locArgs = [
+            'Jacky'
+        ];
+
+        $this->fixture->setBodyLocKey($locKey);
+        $this->fixture->setBodyLocArgs($locArgs);
+        $this->assertEquals(array('title' => 'foo', 'body' => 'bar', 'body_loc_key' => $locKey, 'body_loc_args' => json_encode($locArgs)), $this->fixture->jsonSerialize());
     }
 }


### PR DESCRIPTION
see [fcm document](https://firebase.google.com/docs/cloud-messaging/http-server-ref#notification-payload-support)

1. add some parameters likes **title_loc_key**, **title_loc_args**, **body_loc_key** and **body_loc_args**
2. when send fcm, the parameter **notification**, **notification[title]**, **notification[body]** can be optional
3. notification test must be psr-2 coding style