### PR TITLE
Enable mutable-content (IOS)

### DIFF
--- a/src/Message.php
+++ b/src/Message.php
@@ -127,7 +127,7 @@ class Message implements \JsonSerializable
     public function setMutableContent()
     {
         $this->mutableContent = 1;
-
+    }
     /**
      * @see https://firebase.google.com/docs/cloud-messaging/concept-options#collapsible_and_non-collapsible_messages
      *
@@ -171,13 +171,13 @@ class Message implements \JsonSerializable
         if ($this->delayWhileIdle) {
             $jsonData['delay_while_idle'] = (bool)$this->delayWhileIdle;
         }
-<<<<<<< HEAD
-        if ($this->delayWhileIdle) {
-            $jsonData['mutable_content'] = $this->mutableContent;
-=======
+
+        if ($this->mutableContent) {
+            $jsonData['mutable_content'] = (bool)$this->mutableContent;
+        }
+
         if ($this->contentAvailableFlag === TRUE) {
             $jsonData['content_available'] = TRUE;
->>>>>>> 897979470a596a30ce6782ee229db53f673e54b6
         }
 
         return $jsonData;

--- a/src/Message.php
+++ b/src/Message.php
@@ -28,6 +28,7 @@ class Message implements \JsonSerializable
     private $recipientType;
     private $timeToLive;
     private $delayWhileIdle;
+    private $mutableContent;
 
     /**
      * where should the message go
@@ -116,6 +117,13 @@ class Message implements \JsonSerializable
         return $this;
     }
 
+    public function setMutableContent()
+    {
+        $this->mutableContent = 1;
+
+        return $this;
+    }
+
     public function setData(array $data)
     {
         $this->data = $data;
@@ -148,6 +156,9 @@ class Message implements \JsonSerializable
         }
         if ($this->delayWhileIdle) {
             $jsonData['delay_while_idle'] = (bool)$this->delayWhileIdle;
+        }
+        if ($this->delayWhileIdle) {
+            $jsonData['mutable_content'] = $this->mutableContent;
         }
 
         return $jsonData;


### PR DESCRIPTION
Currently for iOS 10+ devices only. On iOS, use this field to represent mutable-content in the APNS payload. When a notification is sent and this is set to true, the content of the notification can be modified before it is displayed, using a Notification Service app extension. This parameter will be ignored for Android and web.

This is taken from docs: https://firebase.google.com/docs/cloud-messaging/http-server-ref#mutable_content